### PR TITLE
group output by directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,14 @@ runs:
       run: |
         status=0
         for dir in $(find . \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod$::'); do
-          echo "#=#=#=# $dir #=#=#=#"
           pushd $dir > /dev/null
+          echo "::group::$dir"
           ( 
             ${{ inputs.run }}
           )
+          echo "::endgroup::"
           s=$?
           if [[ $s != 0 ]]; then status=$s; fi
           popd > /dev/null
-          echo -e "\n\n"
         done
         exit $status


### PR DESCRIPTION
I wasn't aware that this is possible with GitHub Actions: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines.