### PR TITLE
only use a group when we're in a multi-module repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,15 @@ runs:
     - shell: bash
       run: |
         status=0
-        for dir in $(find . \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod$::'); do
+        dirs=$(find . \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod$::')
+        len=${#dirs[@]}
+        for dir in $dirs; do
           pushd $dir > /dev/null
-          echo "::group::$dir"
+          if [[ $len > 1 ]]; then echo "::group::$dir"; fi
           ( 
             ${{ inputs.run }}
           )
-          echo "::endgroup::"
+          if [[ $len > 1 ]]; then echo "::endgroup::"; fi
           s=$?
           if [[ $s != 0 ]]; then status=$s; fi
           popd > /dev/null


### PR DESCRIPTION
This makes it slightly easier to debug a test failure in non-multi-module repos, because you don't have to expand the `.` group first.