### PR TITLE
fix counting of directories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
       run: |
         status=0
         dirs=$(find . \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod$::')
-        len=${#dirs[@]}
+        len=$(echo "$dirs" | wc -l | tr -d ' ')
         for dir in $dirs; do
           pushd $dir > /dev/null
           if [[ $len > 1 ]]; then echo "::group::$dir"; fi


### PR DESCRIPTION
`find` returns one directory per line, not an array.

I'm not really sure why this worked (occasionally) at all. This should be more robust.