### PR TITLE
Revert "Merge pull request #8 from protocol/configure-shell"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,26 +8,11 @@ inputs:
   working-directory:
     description: "working directory"
     required: false
-  shell:
-    description: "shell (options: 'bash' or 'msys2 {0}')"
-    default: "bash"
-    required: false
 
 runs:
   using: "composite"
   steps:
-    - name: create bash-or-msys2 (for bash)
-      shell: bash
-      if: inputs.shell == 'bash'
-      run: sudo ln -sf $(which bash) /usr/local/bin/bash-or-msys2
-    - name: create bash-or-msys2 (for msys2)
-      shell: bash
-      if: inputs.shell == 'msys2 {0}'
-      run: |
-        if [[ ! -f "D:/a/_temp/setup-msys2/bash-or-msys2.cmd" ]]; then
-          powershell New-Item -ItemType SymbolicLink -Path "D:/a/_temp/setup-msys2/bash-or-msys2.cmd" -Target "D:/a/_temp/setup-msys2/msys2.cmd"
-        fi
-    - shell: bash-or-msys2 {0}
+    - shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         status=0


### PR DESCRIPTION
This reverts commit 9d28aab64a8791076f7e54c487490aca768a200b, reversing
changes made to a9324050387ecb413e92dac85a9def4bef505d46.

Reverting the changes introduced in #8 because we were able to start using msys2 on windows just by modifying the PATH instead (as per https://github.com/protocol/.github/pull/232#pullrequestreview-814528187). 